### PR TITLE
Added LDLIBS to makefile template 

### DIFF
--- a/cvxpy_codegen/templates/Makefile.jinja
+++ b/cvxpy_codegen/templates/Makefile.jinja
@@ -1,11 +1,12 @@
 OPTS = -Wall
 CC = gcc
 LDFLAGS = -Lecos
-CFLAGS = -Wall -lm
+LDLIBS = -lecos -lm
+CFLAGS = -Wall
 INCLUDE = -Iecos/include  -Iecos/external/SuiteSparse_config
 
 example_problem: solver_intf.o codegen.o linop.o param.o example_problem.o ecos/libecos.a
-	$(CC) $(LDFLAGS) $(CFLAGS) solver_intf.o codegen.o linop.o param.o example_problem.o -lecos -o $@
+	$(CC) $(LDFLAGS) $(CFLAGS) solver_intf.o codegen.o linop.o param.o example_problem.o -o $@ $(LDLIBS)
 
 solver_intf.o: solver_intf.c
 	$(CC) $(CFLAGS) $(INCLUDE) -c $<


### PR DESCRIPTION
Moved -lecos and -lm library includes into LDLIBS and changed arg order to be compatible. Fixes 'undefined reference to log/sqrt' error during compile with gcc v5.4.0.

More context on the type of error in this thread: http://stackoverflow.com/questions/13249610/how-to-use-ldflags-in-makefile